### PR TITLE
Add feature to switch between reqwest native-tls/rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = {version = "0.21.0", optional = true}
 const_format = {version = "0.2.30", optional = true}
 log = {version = "0.4.17", optional = true}
 rand = {version = "0.8.5", optional = true}
-reqwest = {version = "0.11.12", features = ["json"], optional = true}
+reqwest = {version = "0.11.12", default-features = false, features = ["json"], optional = true}
 sha2 = {version = "0.10.6", optional = true}
 
 # rate limit sleep dependencies
@@ -34,7 +34,7 @@ serde_json = "1.0.87"
 tokio = {version = "1.22.0", features = ["rt-multi-thread", "macros"]}
 
 [features]
-default = ["async", "tokio_sleep"]
+default = ["async", "tokio_sleep", "native-tls"]
 # default = ["async_std_sleep"]
 
 async = ["dep:reqwest", "dep:sha2", "dep:log", "dep:rand", "dep:base64", "dep:const_format", "dep:async-trait"]
@@ -42,6 +42,9 @@ sync = ["dep:reqwest", "dep:sha2", "dep:log", "dep:rand", "dep:base64", "dep:con
 
 async_std_sleep = ["dep:async-std"]
 tokio_sleep = ["dep:tokio"]
+
+native-tls = ["reqwest?/native-tls"]
+rustls-tls = ["reqwest?/rustls-tls"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I cannot (and prefer not to) use OpenSSL (native-tls) because of the recent change from libssl1 to libssl3, some distributions haven't or won't switch to libssl3 (Ex. Ubuntu 20.04), and some CI images still ship libssl1.